### PR TITLE
Display error message when camera is not available

### DIFF
--- a/index.css
+++ b/index.css
@@ -23,6 +23,10 @@ body {
   border-style: none;
 }
 
+#capture:disabled {
+  background-color: #9e9e9e;
+}
+
 #file-input {
   width: 50%;
   height: 40px;
@@ -35,4 +39,21 @@ body {
 
 #snapshot {
   opacity: 0;
+}
+
+#video-container {
+  position: relative;
+}
+
+#video-container .error-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  color: #fff;
+  font-size: 14px;
 }

--- a/index.html
+++ b/index.html
@@ -38,9 +38,11 @@
     <img id="demo_img" src="./sample.png" />
     <br><br>
 
-    <!-- びでお(実はめっっちゃちっちゃいのが隠れてる) -->
-    <video id="player" muted autoplay playsinline></video>
-    <canvas id="canvas" width="300" height="100"></canvas>
+    <div id="video-container">
+      <!-- びでお(実はめっっちゃちっちゃいのが隠れてる) -->
+      <video id="player" muted autoplay playsinline></video>
+      <canvas id="canvas" width="300" height="100"></canvas>
+    </div>
 
     <div>
       <button class="button" id="capture"> カメラ認識！ </button>
@@ -113,6 +115,24 @@
       };
 
       const handleError = function (error) {
+        const captureButton = document.getElementById("capture");
+        captureButton.disabled = true;
+      
+        const videoContainer = document.getElementById("video-container");
+        const messages = ["カメラが使えないよ🥹"];
+        if (error.name === "NotAllowedError") {
+          messages.push("カメラのアクセスを許可してね");
+        }
+      
+        const errorMessage = `
+          <div class="error-message">
+            <p>
+              ${messages.join("<br />")}
+            </p>
+          </div>
+        `;
+        videoContainer.insertAdjacentHTML("beforeend", errorMessage);
+
         console.error('navigator.getUserMedia error: ', error);
       };
 


### PR DESCRIPTION
Closes https://github.com/geum-ztmy/zutomayo_OCR/issues/1

## 変更点

- カメラにアクセスができないとき、エラーメッセージを表示するようにした
    - ブロックされている場合は、「許可してください」の文言も表示するようにしている
- カメラにアクセスできないとき、「カメラ認識！」ボタンを無効化するようにした

## スクリーンショット

![](https://github.com/geum-ztmy/zutomayo_OCR/assets/39073321/2499c083-970a-4baf-aba2-d9e5f127b7b5)
